### PR TITLE
Archive API data to Postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -394,18 +415,6 @@ name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
-
-[[package]]
-name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "futures-core",
- "futures-sink",
- "pin-project",
- "spin",
-]
 
 [[package]]
 name = "fnv"
@@ -636,6 +645,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,17 +824,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
-name = "libsqlite3-sys"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +871,15 @@ name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
+name = "md-5"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -1374,6 +1399,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,6 +1584,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,15 +1652,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "sqlformat"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,40 +1680,47 @@ checksum = "fa8241483a83a3f33aa5fff7e7d9def398ff9990b2752b6c6112b83c6d246029"
 dependencies = [
  "ahash 0.7.6",
  "atoi",
+ "base64 0.13.0",
  "bitflags",
  "byteorder",
  "bytes",
  "crc",
  "crossbeam-queue",
+ "dirs",
  "dotenvy",
  "either",
  "event-listener",
- "flume",
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-intrusive",
  "futures-util",
  "hashlink",
  "hex",
+ "hkdf",
+ "hmac",
  "indexmap",
  "itoa",
  "libc",
- "libsqlite3-sys",
  "log",
+ "md-5",
  "memchr",
  "once_cell",
  "paste",
  "percent-encoding",
+ "rand",
  "serde",
+ "serde_json",
+ "sha1",
  "sha2",
  "smallvec",
  "sqlformat",
  "sqlx-rt",
  "stringprep",
  "thiserror",
+ "time",
  "tokio-stream",
  "url",
+ "whoami",
 ]
 
 [[package]]
@@ -1727,6 +1772,12 @@ name = "sublime_fuzzy"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7986063f7c0ab374407e586d7048a3d5aac94f103f751088bf398e07cd5400"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -2306,6 +2357,16 @@ dependencies = [
  "either",
  "lazy_static",
  "libc",
+]
+
+[[package]]
+name = "whoami"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c70234412ca409cc04e864e89523cb0fc37f5e1344ebed5a3ebf4192b6b9f68"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ opentelemetry-otlp = { version = "0.10", features = ["http-proto", "reqwest-clie
 opentelemetry = { version = "0.17", features = ["rt-tokio"] }
 opentelemetry-semantic-conventions = "0.9"
 axum-prometheus = "0.3.3"
-sqlx = { version = "0.6.3", features = ["sqlite", "runtime-tokio-native-tls", "macros", "offline"] }
+sqlx = { version = "0.6.3", features = ["postgres", "time", "runtime-tokio-native-tls", "macros", "offline"] }
 time = { version = "0.3.21", features = ["std", "formatting"] }
 thiserror = "1.0.40"

--- a/fly.toml
+++ b/fly.toml
@@ -47,6 +47,3 @@ kill_timeout = "5s"
 [metrics]
 port = 9091
 path = "/metrics"
-
-[env]
-DATABASE_URL = "sqlite:///data/bikeshare.db"

--- a/migrations/20230603150121_cache.sql
+++ b/migrations/20230603150121_cache.sql
@@ -1,12 +1,12 @@
 CREATE TABLE IF NOT EXISTS cache (
-	timestamp TEXT NOT NULL,
-	name TEXT,
-	longitude REAL,
-	latitude REAL,
-	total_slots INTEGER,
-	free_slots INTEGER,
-	avl_bikes INTEGER,
-	operative INTEGER,
-	style TEXT,
-	is_estation INTEGER
+	time        TIMESTAMP WITH TIME ZONE NOT NULL,
+	name        TEXT NOT NULL,
+	longitude   REAL,
+	latitude    REAL,
+	total_slots INTEGER NOT NULL,
+	free_slots  INTEGER NOT NULL,
+	avl_bikes   INTEGER NOT NULL,
+	operative   BOOLEAN NOT NULL,
+	style       TEXT NOT NULL,
+	is_estation BOOLEAN NOT NULL
 );

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,13 +1,24 @@
 {
-  "db": "SQLite",
-  "ef4d9f859d306af385292fe53fbc4c03c9fdf848fc736eee5e0942ac248fe538": {
+  "db": "PostgreSQL",
+  "fda081c73d1f8990c711a39467fe1466c7f92c27860fc9486862539440c42b5f": {
     "describe": {
       "columns": [],
       "nullable": [],
       "parameters": {
-        "Right": 10
+        "Left": [
+          "Timestamptz",
+          "Text",
+          "Float4",
+          "Float4",
+          "Int4",
+          "Int4",
+          "Int4",
+          "Bool",
+          "Text",
+          "Bool"
+        ]
       }
     },
-    "query": "INSERT INTO cache\n                (timestamp, name, longitude, latitude, total_slots, free_slots, avl_bikes, operative, style, is_estation)\n                VALUES (?,?,?,?,?,?,?,?,?,?)"
+    "query": "INSERT INTO\n        cache(time, name, longitude, latitude, total_slots,\n        free_slots, avl_bikes, operative, style, is_estation)\n        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10);"
   }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -80,8 +80,8 @@ pub struct StationStatus {
 
 #[derive(Serialize, Copy, Clone, Debug)]
 pub struct Coordinate {
-    pub latitude: f64,
-    pub longitude: f64,
+    pub latitude: f32,
+    pub longitude: f32,
 }
 
 fn deserialize_coordinate<'de, D>(deserializer: D) -> Result<Option<Coordinate>, D::Error>
@@ -101,7 +101,7 @@ where
         where
             E: serde::de::Error,
         {
-            let mut coords = v.split(',').map(|c| c.trim().parse::<f64>());
+            let mut coords = v.split(',').map(|c| c.trim().parse::<f32>());
 
             match (coords.next(), coords.next()) {
                 (Some(Ok(latitude)), Some(Ok(longitude))) => Ok(Some(Coordinate {

--- a/src/db.rs
+++ b/src/db.rs
@@ -32,9 +32,9 @@ impl Db {
     fn make_copy_data(api_data: &[StationStatus]) -> std::io::Result<Vec<u8>> {
         let mut buf = Vec::new();
         let timestamp = OffsetDateTime::now_utc();
-        let lines = api_data.iter().map(|status| {
-            BikeshareData::from_station_status(status, timestamp).to_text_row()
-        });
+        let lines = api_data
+            .iter()
+            .map(|status| BikeshareData::from_station_status(status, timestamp).to_text_row());
         for line in lines {
             writeln!(&mut buf, "{}", line)?;
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,77 @@
+use sqlx::{postgres::PgPoolOptions, query, Result};
+use time::OffsetDateTime;
+
+use crate::api::StationStatus;
+
+#[derive(Debug, Clone)]
+pub struct Db {
+    inner: sqlx::PgPool,
+}
+
+impl Db {
+    pub async fn new(url: &str) -> Result<Self> {
+        Ok(Self {
+            inner: PgPoolOptions::new().connect(url).await?,
+        })
+    }
+
+    pub async fn archive_api_data(&self, api_data: &[StationStatus]) -> Result<()> {
+        let transaction = self.inner.begin().await?;
+        let timestamp = OffsetDateTime::now_utc();
+        for row in api_data
+            .iter()
+            .map(|status| BikeshareData::from_station_status(status, timestamp))
+        {
+            query!(
+                r#"INSERT INTO
+        cache(time, name, longitude, latitude, total_slots,
+        free_slots, avl_bikes, operative, style, is_estation)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10);"#,
+                row.time,
+                row.name,
+                row.latitude,
+                row.longitude,
+                row.total_slots,
+                row.free_slots,
+                row.avl_bikes,
+                row.operative,
+                row.style,
+                row.is_estation
+            )
+            .execute(&self.inner)
+            .await?;
+        }
+        transaction.commit().await
+    }
+}
+
+#[derive(sqlx::FromRow)]
+pub struct BikeshareData {
+    time: OffsetDateTime,
+    name: String,
+    latitude: Option<f32>,
+    longitude: Option<f32>,
+    total_slots: i32,
+    free_slots: i32,
+    avl_bikes: i32,
+    operative: bool,
+    style: String,
+    is_estation: bool,
+}
+
+impl BikeshareData {
+    pub fn from_station_status(status: &StationStatus, time: OffsetDateTime) -> Self {
+        Self {
+            time,
+            name: status.name.clone(),
+            latitude: status.coordinates.map(|c| c.latitude),
+            longitude: status.coordinates.map(|c| c.longitude),
+            total_slots: status.total_slots.into(),
+            free_slots: status.free_slots.into(),
+            avl_bikes: status.avl_bikes.into(),
+            operative: status.operative,
+            style: status.style.clone(),
+            is_estation: status.is_estation,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,14 @@ pub mod status;
 use tokio::sync::Mutex;
 
 use api::BikeshareApi;
-use cache::{Cache, Stale};
+use cache::Cache;
 
 const API_URL: &'static str = "https://vancouver-ca.smoove.pro/api-public/stations";
 
 #[derive(Debug)]
 pub struct ServerState {
     api: BikeshareApi,
-    cache: Mutex<Cache<Stale>>,
+    cache: Mutex<Cache>,
 }
 
 impl ServerState {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
-#![allow(unused_variables)]
+#![allow(dead_code)]
 mod api;
 mod cache;
+mod db;
 pub mod status;
 
 use tokio::sync::Mutex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,15 +13,13 @@ const API_URL: &'static str = "https://vancouver-ca.smoove.pro/api-public/statio
 
 #[derive(Debug)]
 pub struct ServerState {
-    api: BikeshareApi,
     cache: Mutex<Cache>,
 }
 
 impl ServerState {
     pub async fn new() -> Self {
         Self {
-            api: BikeshareApi::new(),
-            cache: Mutex::new(Cache::new()),
+            cache: Mutex::new(Cache::new(BikeshareApi::new())),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod cache;
 mod db;
 pub mod status;
 
+use db::Db;
 use tokio::sync::Mutex;
 
 use api::BikeshareApi;
@@ -17,9 +18,13 @@ pub struct ServerState {
 }
 
 impl ServerState {
-    pub async fn new() -> Self {
+    pub async fn new(db_url: Option<String>) -> Self {
+        let db = match db_url {
+            Some(url) => Db::new(&url).await.ok(),
+            None => None,
+        };
         Self {
-            cache: Mutex::new(Cache::new(BikeshareApi::new())),
+            cache: Mutex::new(Cache::new(BikeshareApi::new(), db)),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,9 @@ async fn main() {
     let app = Router::new()
         .route("/status", get(station_status))
         .route("/healthcheck", get(|| async { axum::http::StatusCode::OK }))
-        .with_state(Arc::new(ServerState::new().await))
+        .with_state(Arc::new(
+            ServerState::new(std::env::var("DATABASE_URL").ok()).await,
+        ))
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(

--- a/src/status.rs
+++ b/src/status.rs
@@ -28,7 +28,7 @@ pub async fn station_status(
         .cache
         .lock()
         .await
-        .lookup(query.name.as_deref(), &state.api)
+        .lookup(query.name.as_deref())
         .await?
         .into_iter()
         .collect();

--- a/src/status.rs
+++ b/src/status.rs
@@ -28,9 +28,8 @@ pub async fn station_status(
         .cache
         .lock()
         .await
-        .refresh(&state.api)
+        .lookup(query.name.as_deref(), &state.api)
         .await?
-        .lookup(query.name.as_deref())
         .into_iter()
         .collect();
     Ok(Json(stations))


### PR DESCRIPTION
- Add postgres wrapper for archiving API data
- Simply cache implementation to avoid exposing the cache's state to its consumers
- Move BikeshareApi into Cache struct
- Archive api data to Postgres
