### PR TITLE
Report timestamp with api data. Add query parameter to purge cache and fetch fresh data.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ opentelemetry = { version = "0.17", features = ["rt-tokio"] }
 opentelemetry-semantic-conventions = "0.9"
 axum-prometheus = "0.3.3"
 sqlx = { version = "0.6.3", features = ["postgres", "time", "runtime-tokio-native-tls", "macros", "offline"] }
-time = { version = "0.3.21", features = ["std", "formatting"] }
+time = { version = "0.3.21", features = ["std", "serde-human-readable"] }
 thiserror = "1.0.40"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -61,6 +61,10 @@ impl Cache {
             .cloned()
             .collect::<Vec<StationStatus>>())
     }
+
+    pub fn timestamp(&self) -> OffsetDateTime {
+        self.timestamp
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -65,6 +65,11 @@ impl Cache {
     pub fn timestamp(&self) -> OffsetDateTime {
         self.timestamp
     }
+
+    pub fn invalidate(&mut self) {
+        self.timestamp = OffsetDateTime::UNIX_EPOCH;
+        self.entries.clear();
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -65,8 +65,8 @@ impl Cache {
 
 #[derive(Debug, thiserror::Error)]
 pub enum CacheError {
-    #[error("Error fetching data from the bikeshare api")]
+    #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
-    #[error("Error writing api data to the database")]
+    #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -16,6 +16,14 @@ use crate::{api::StationStatus, cache::CacheError};
 #[derive(Deserialize, Debug)]
 pub struct StationQuery {
     name: Option<String>,
+    #[serde(default = "StationQuery::default_cached_value")]
+    cached: bool,
+}
+
+impl StationQuery {
+    fn default_cached_value() -> bool {
+        true
+    }
 }
 
 #[derive(Serialize, Debug)]
@@ -32,6 +40,9 @@ pub async fn station_status(
     query: Query<StationQuery>,
 ) -> Result<Json<StationResponse>, StatusError> {
     let mut cache = state.cache.lock().await;
+    if !query.cached {
+        cache.invalidate();
+    }
     let stations: Vec<StationStatus> = cache
         .lookup(query.name.as_deref())
         .await?

--- a/src/status.rs
+++ b/src/status.rs
@@ -38,7 +38,7 @@ pub async fn station_status(
 /// Errors that can occur when retrieving the status of a bike station
 #[derive(Debug, thiserror::Error)]
 pub enum StatusError {
-    #[error("Error retrieving bikeshare data from the cache")]
+    #[error("Error retrieving bikeshare data from the cache: {0}")]
     Cache(#[from] CacheError),
 }
 


### PR DESCRIPTION
- Forward underlying error messages to user
- Report timestamp along with the list of stations that match the query
- Add cached query parameter so clients can request fresh data
